### PR TITLE
Reduce flash when video files change

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -98,10 +98,10 @@ context("Test the overall app", () => {
       getTextArea().type(exampleText);
       getTextArea().blur();
       getTextArea().should("have.text", exampleText);
-      getStressControl().click();
+      getStressControl().click().wait(760);
       getTextArea().should("have.text", "");
       getTextArea().type(exampleText2);
-      getStressControl().click();
+      getStressControl().click().wait(760);
       getTextArea().should("have.text", exampleText);
       getStressControl().click();
       getTextArea().should("have.text", exampleText2);

--- a/src/components/animation-app.tsx
+++ b/src/components/animation-app.tsx
@@ -6,6 +6,7 @@ import { SilhouettePane } from "./silhouette-pane";
 import { Title } from "./title";
 import { VideoView } from "./video-view";
 import { AppContext } from "../hooks/use-app-context";
+import { delayControl } from "../utils/app-common";
 import { renderControls } from "../utils/app-data";
 
 import { aniVideos } from "../assets/videos/video-data";
@@ -26,6 +27,7 @@ export const AnimationApp = ({ ac, setKeyVisible }: AnimationAppProps) => {
 
   const [control1, setControl1] = useState(false);
   const [control2, setControl2] = useState(false);
+  const [disableControls, setDisableControls] = useState(false);
 
   // State and components for stress pane
   const [lowStressExample, setLowStressExample] = useState("");
@@ -74,7 +76,11 @@ export const AnimationApp = ({ ac, setKeyVisible }: AnimationAppProps) => {
         <SilhouettePane ac={ac} hasZoomed={hasZoomed} setHasZoomed={setHasZoomed} />
         <div className="controls-pane">
           <Title ac={ac} text="Controls" />
-          { renderControls({ ac, onChanges: [setControl1, setControl2] }) }
+          { renderControls({ ac, disabled: disableControls,
+            onChanges: [
+              delayControl(setControl1, setDisableControls),
+              delayControl(setControl2, setDisableControls)
+            ] }) }
           <div className="key-box animation">
             <KeyButton ac={ac} onClick={() => setKeyVisible(state => !state)} />
           </div>

--- a/src/components/control-option.tsx
+++ b/src/components/control-option.tsx
@@ -10,15 +10,16 @@ export interface PartialControlOptionProps {
 }
 export interface ControlOptionProps extends PartialControlOptionProps{
   ac: AppContext;
+  disabled?: boolean;
   onChange?: (value: boolean) => void;
 }
-export const ControlOption = ({ ac, label, onChange, options }: ControlOptionProps) => {
+export const ControlOption = ({ ac, disabled, label, onChange, options }: ControlOptionProps) => {
   return (
     <div className="control-option">
       <div className="control-option-label">{`${label}:`}</div>
       <div className="control-option-main">
         {options[0]}
-        <ToggleControl ac={ac} onChange={onChange} />
+        <ToggleControl ac={ac} disabled={disabled} onChange={onChange} />
         {options[1]}
       </div>
     </div>

--- a/src/components/sim-graph.tsx
+++ b/src/components/sim-graph.tsx
@@ -57,7 +57,7 @@ interface IHalfBorder {
 }
 const HalfBorder = ({ height, width }: IHalfBorder) => (
   <>
-    <line x1="0" y1="0" x2="0" y2={height} stroke="black" stroke-width="4" />
+    <line x1="0" y1="0" x2="0" y2={height} stroke="black" strokeWidth="4" />
     <line x1="0" y1={height} x2={width} y2={height} stroke="black" strokeWidth="4" />
   </>
 );

--- a/src/components/simulation-app.tsx
+++ b/src/components/simulation-app.tsx
@@ -73,7 +73,7 @@ export const SimulationApp = ({ ac, setKeyVisible }: SimulationAppProps) => {
         { renderControls({ ac, disabled: disableControls,
           onChanges: [
             delayControl(setControl1, setDisableControls),
-            delayControl(setControl2, setDisableControls, 5000),
+            delayControl(setControl2, setDisableControls),
             delayControl(setControl3, setDisableControls)
           ] }) }
         <div />

--- a/src/components/simulation-app.tsx
+++ b/src/components/simulation-app.tsx
@@ -6,6 +6,7 @@ import { KeyButton } from "./app-button";
 import { AppContainer } from "./app-container";
 import { Coord, SimGraph } from "./sim-graph";
 import { AppContext } from "../hooks/use-app-context";
+import { delayControl } from "../utils/app-common";
 import { graphData, renderControls } from "../utils/app-data";
 
 import { simVideos } from "../assets/videos/video-data";
@@ -29,6 +30,7 @@ export const SimulationApp = ({ ac, setKeyVisible }: SimulationAppProps) => {
   const [control1, setControl1] = useState(false);
   const [control2, setControl2] = useState(false);
   const [control3, setControl3] = useState(false);
+  const [disableControls, setDisableControls] = useState(false);
 
   // Mark the video as incomplete whenever a control changes
   useEffect(() => {
@@ -68,7 +70,12 @@ export const SimulationApp = ({ ac, setKeyVisible }: SimulationAppProps) => {
     <AppContainer ac={ac} title={ac.o("SIMULATIONTITLE")}>
       <div className="options-row">
         <RowHeader backgroundSvg={<OptionsLabelBack />} headerText={ac.t("SIMOPTIONSHEADER")} />
-        { renderControls({ ac, onChanges: [setControl1, setControl2, setControl3] }) }
+        { renderControls({ ac, disabled: disableControls,
+          onChanges: [
+            delayControl(setControl1, setDisableControls),
+            delayControl(setControl2, setDisableControls, 5000),
+            delayControl(setControl3, setDisableControls)
+          ] }) }
         <div />
       </div>
       <div className="app-row">

--- a/src/components/toggle-control.scss
+++ b/src/components/toggle-control.scss
@@ -37,7 +37,7 @@ $border-gray: #949494;
     border-radius: 50%;
     border: 2px solid $border-gray;
     transition-property: transform;
-    transition-duration: .25s;
+    transition-duration: .6s;
 
     &.animation {
       background-color: vars.$ani-light-7;

--- a/src/components/toggle-control.tsx
+++ b/src/components/toggle-control.tsx
@@ -9,17 +9,20 @@ interface IProps {
   ac: AppContext;
   className?: string;
   dataTest?: string;
+  disabled?: boolean;
   initialValue?: boolean;
   onChange?: (value: boolean) => void;
   title?: string;
 }
 
-const ToggleControl: React.FC<IProps> = ({ ac, className, dataTest, initialValue, onChange, title }) => {
+const ToggleControl: React.FC<IProps> = ({ ac, className, dataTest, disabled, initialValue, onChange, title }) => {
   const [value, setValue] = useState(initialValue || false);
 
   const handleClick = () => {
-    onChange?.(!value);
-    setValue(!value);
+    if (!disabled) {
+      onChange?.(!value);
+      setValue(!value);
+    }
   };
 
   const onClass = value ? "toggle-on" : "";

--- a/src/components/video-view.scss
+++ b/src/components/video-view.scss
@@ -6,6 +6,8 @@
 
   .video-pane {
     position: relative;
+    overflow: hidden;
+    
     width: 456px;
     height: 284px;
     padding: 2px;
@@ -54,6 +56,7 @@
     }
 
     .video-view-video {
+      position: absolute;
       width: 456px;
       margin-top: 1px;
     }

--- a/src/components/video-view.scss
+++ b/src/components/video-view.scss
@@ -7,7 +7,7 @@
   .video-pane {
     position: relative;
     overflow: hidden;
-    
+
     width: 456px;
     height: 284px;
     padding: 2px;
@@ -57,8 +57,9 @@
 
     .video-view-video {
       position: absolute;
+      left: 2px;
+      top: 3px;
       width: 456px;
-      margin-top: 1px;
     }
 
     .video-title {

--- a/src/components/video-view.tsx
+++ b/src/components/video-view.tsx
@@ -34,6 +34,7 @@ export const VideoView = ({
   // Basic video state
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [duration, setDuration] = useState(0);
+  const [loading, setLoading] = useState(true);
 
   // The back video is used to prevent the video from flashing when the video file changes
   const backVideoRef = useRef<HTMLVideoElement | null>(null);
@@ -72,6 +73,7 @@ export const VideoView = ({
   // Show the front video when it's finished loading
   const handleLoadedData = () => {
     setBackVideoFile(videoFile);
+    setLoading(false);
   };
 
   // Set the duration of the video when its length is known
@@ -91,6 +93,7 @@ export const VideoView = ({
   useEffect(() => {
     pause();
     videoRef.current?.load();
+    setLoading(true);
   }, [pause, videoRef, videoFile]);
 
   // Reload the back video when its video file changes
@@ -101,10 +104,10 @@ export const VideoView = ({
   // Keep the back video up to date with the front video
   useEffect(() => {
     const backVideo = backVideoRef.current;
-    if (backVideo) {
+    if (backVideo && !loading) {
       backVideo.currentTime = percentComplete * duration;
     }
-  }, [duration, percentComplete]);
+  }, [duration, loading, percentComplete]);
 
   // Pause the video when it becomes disabled
   useEffect(() => {

--- a/src/components/video-view.tsx
+++ b/src/components/video-view.tsx
@@ -38,8 +38,6 @@ export const VideoView = ({
   // The back video is used to prevent the video from flashing when the video file changes
   const backVideoRef = useRef<HTMLVideoElement | null>(null);
   const [backVideoFile, setBackVideoFile] = useState<any>();
-  const normalStyle = { left: 2, top: 2 };
-  const [frontStyle, setFrontStyle] = useState<Record<string, any>>(normalStyle);
 
   // Keep percentComplete updated based on the video's state
   useEffect(() => {
@@ -48,10 +46,10 @@ export const VideoView = ({
         const pc = videoRef.current.currentTime / duration;
         setPercentComplete(pc);
       }
-      return () => {
-        clearInterval(tickInterval);
-      };
     }, 30);
+    return () => {
+      clearInterval(tickInterval);
+    };
   }, [duration, setPercentComplete]);
 
   // Update the target index (timelineMark) to be the closest to the percent complete
@@ -71,16 +69,8 @@ export const VideoView = ({
     }
   }, [percentComplete, setTargetVideoIndex, timelineMarks]);
 
-  // Hide the front video when the video file changes
-  useEffect(() => {
-    const loadingStyle = { left: 460, top: 2 };
-    setFrontStyle(loadingStyle);
-    videoFile; // eslint-disable-line no-unused-expressions
-  }, [videoFile]);
-
   // Show the front video when it's finished loading
   const handleLoadedData = () => {
-    setFrontStyle(normalStyle);
     setBackVideoFile(videoFile);
   };
 
@@ -175,7 +165,6 @@ export const VideoView = ({
         <video
           ref={backVideoRef}
           className={clsx("video-view-video", extraClass)}
-          style={normalStyle}
         >
           <source src={backVideoFile || aniVideos.tissue.heart[0][0]} type={"video/mp4"} />
         </video>
@@ -185,7 +174,6 @@ export const VideoView = ({
           onLoadedMetadata={handleLoadedMetadata}
           onEnded={onEnded}
           className={clsx("video-view-video", extraClass)}
-          style={frontStyle}
         >
           <source src={videoFile || aniVideos.tissue.heart[0][0]} type={"video/mp4"} />
         </video>

--- a/src/components/video-view.tsx
+++ b/src/components/video-view.tsx
@@ -70,7 +70,7 @@ export const VideoView = ({
     }
   }, [percentComplete, setTargetVideoIndex, timelineMarks]);
 
-  // Show the front video when it's finished loading
+  // Update the back video after the front video is finished loading
   const handleLoadedData = () => {
     setBackVideoFile(videoFile);
     setLoading(false);
@@ -152,6 +152,7 @@ export const VideoView = ({
     }
   };
 
+  const kDefaultVideo = aniVideos.tissue.heart[0][0];
   return (
     <div className={clsx("video-view", extraClass)}>
       <VideoControls
@@ -169,7 +170,7 @@ export const VideoView = ({
           ref={backVideoRef}
           className={clsx("video-view-video", extraClass)}
         >
-          <source src={backVideoFile || aniVideos.tissue.heart[0][0]} type={"video/mp4"} />
+          <source src={backVideoFile || kDefaultVideo} type={"video/mp4"} />
         </video>
         <video
           ref={videoRef}
@@ -178,7 +179,7 @@ export const VideoView = ({
           onEnded={onEnded}
           className={clsx("video-view-video", extraClass)}
         >
-          <source src={videoFile || aniVideos.tissue.heart[0][0]} type={"video/mp4"} />
+          <source src={videoFile || kDefaultVideo} type={"video/mp4"} />
         </video>
         <PaneTitle extraClass="video-title" title={title} />
         {disabled && (

--- a/src/utils/app-common.tsx
+++ b/src/utils/app-common.tsx
@@ -1,0 +1,10 @@
+// Functions used by both animations and simulations
+
+export const delayControl =
+  (setControl: (val: boolean) => void, setDisableControls: (val: boolean) => void, delay?: number) => (
+    (controlVal: boolean) => {
+      setDisableControls(true);
+      setControl(controlVal);
+      setTimeout(() => setDisableControls(false), delay || 750);
+    }
+  );

--- a/src/utils/app-common.tsx
+++ b/src/utils/app-common.tsx
@@ -5,6 +5,6 @@ export const delayControl =
     (controlVal: boolean) => {
       setDisableControls(true);
       setControl(controlVal);
-      setTimeout(() => setDisableControls(false), delay || 750);
+      setTimeout(() => setDisableControls(false), delay || 600);
     }
   );

--- a/src/utils/app-data.tsx
+++ b/src/utils/app-data.tsx
@@ -58,9 +58,10 @@ const getControls = (ac: AppContext): (PartialControlOptionProps | string)[] => 
 };
 interface IRenderControls {
   ac: AppContext;
+  disabled?: boolean;
   onChanges?: ((value: boolean) => void)[]; // A list of change functions that will be assigned to the controls in order
 }
-export const renderControls = ({ ac, onChanges }: IRenderControls) => {
+export const renderControls = ({ ac, disabled, onChanges }: IRenderControls) => {
   const Divider = () => <div className={clsx("divider", ac.mode)} />;
 
   let onChangeIndex = 0;
@@ -69,6 +70,7 @@ export const renderControls = ({ ac, onChanges }: IRenderControls) => {
       ? <Divider key={control} />
       : <ControlOption
         ac={ac}
+        disabled={disabled}
         key={control.label}
         label={control.label}
         onChange={onChanges && onChangeIndex < onChanges.length ? onChanges[onChangeIndex++] : undefined}


### PR DESCRIPTION
This PR reduces the amount of flashing that happens when videos change. It's not perfect, and the videos still flash sometimes, but it's definitely better. It accomplishes this by displaying two videos on top of each other, and only changing the source of the back video when the front video has loaded the new source. Controls have also been throttled because switching the videos very quickly can break the double video strategy.