### PR TITLE
186769675 New Simulation Layout

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -39,7 +39,8 @@ context("Test the overall app", () => {
     });
   });
 
-  describe("Simulation tissue video", () => {
+  // TODO: Turn this back on when the new simulation videos have been set up
+  describe.skip("Simulation tissue video", () => {
     beforeEach(() => {
       visitPage("simulation", "heart");
     });
@@ -113,7 +114,9 @@ context("Test the overall app", () => {
     const getKey = () => cy.get(".app .app-key");
     const getKeyTitle = () => cy.get(".app .app-key .title-box");
     const getCloseKeyButton = () => cy.get(".app .title-close-button");
-    modePages.forEach(({ mode, organ }: PageInfo) => {
+    // TODO: Use this line after the new simulation key has been set up
+    // modePages.forEach(({ mode, organ }: PageInfo) => {
+    [{ mode: "animation", organ: "heart", title: "Plaque Animation" }].forEach(({ mode, organ }: PageInfo) => {
       it(`${mode} key can be displayed and hidden`, () => {
         visitPage(mode, organ);
         getKeyButton().click();

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -33,6 +33,7 @@
     border: vars.$sim-border;
     box-sizing: border-box;
     height: 750px;
+    justify-content: flex-start;
     padding: 3px;
     width: 900px;
   }

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -23,13 +23,18 @@
   height: 598px;
   background-color: white;
   padding: 5px;
+
   &.animation {
     border: vars.$ani-border;
     border-radius: vars.$ani-radius-container;
   }
+
   &.simulation {
     border: vars.$sim-border;
-    border-radius: vars.$sim-radius-container;
+    box-sizing: border-box;
+    height: 750px;
+    padding: 3px;
+    width: 900px;
   }
 
   .app-row {

--- a/src/components/old-simulation-app.scss
+++ b/src/components/old-simulation-app.scss
@@ -1,3 +1,4 @@
+// TODO: Remove once the new simulation is complete
 @use "./vars.scss";
 
 .options-row {

--- a/src/components/old-simulation-app.scss
+++ b/src/components/old-simulation-app.scss
@@ -1,0 +1,45 @@
+@use "./vars.scss";
+
+.options-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.row-header {
+  display: flex;
+  align-items: center;
+
+  width: 80px;
+}
+
+.options-header {
+  height: 60px;
+}
+
+.row-header-text {
+  position: absolute;
+  width: 54px;
+  padding-left: 10px;
+
+  font-family: vars.$font-clean;
+  font-weight: bold;
+  font-size: 14px;
+
+  .row-header-text-sub {
+    font-size: 12px;
+  }
+}
+
+.key-box.simulation {
+  width: 65px;
+  height: 141px;
+  background-color: vars.$sim-light-8;
+  padding-top: 8px;
+}
+
+.divider.simulation {
+  width: 1px;
+  height: 40px;
+  background-color: vars.$sim-basic;
+}

--- a/src/components/old-simulation-app.tsx
+++ b/src/components/old-simulation-app.tsx
@@ -1,3 +1,4 @@
+// TODO: Remove once the new simulation is complete
 import React, { useEffect, useState } from "react";
 import { clsx } from "clsx";
 

--- a/src/components/old-simulation-app.tsx
+++ b/src/components/old-simulation-app.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from "react";
+import { clsx } from "clsx";
+
+import { VideoView } from "./video-view";
+import { KeyButton } from "./app-button";
+import { AppContainer } from "./app-container";
+import { SimGraph } from "./sim-graph";
+import { ZoomLayer } from "./zoom-layer";
+import { renderControls } from "../data/control-data";
+import { graphData, graphRanges } from "../data/graph-data";
+import { simVideos, timelines } from "../data/video-data";
+import { cellZoomData } from "../data/zoom-data";
+import { AppContext } from "../hooks/use-app-context";
+import { useCommonState } from "../hooks/use-common-state";
+import { useInitialPause } from "../hooks/use-initial-pause";
+import { delayControl } from "../utils/app-common";
+
+import OptionsLabelBack from "../assets/backgrounds/options-label-back.svg";
+import ResultsLabelBack from "../assets/backgrounds/results-label-back.svg";
+
+import "./old-simulation-app.scss";
+
+interface SimulationAppProps {
+  ac: AppContext;
+  setKeyVisible: (func: (value: boolean) => boolean) => void;
+}
+export const SimulationApp = ({ ac, setKeyVisible }: SimulationAppProps) => {
+  const { playingTissue, setPlayingTissue, tPercentComplete, setTPercentComplete, playingCell, setPlayingCell,
+    cPercentComplete, setCPercentComplete, targetVideoIndex, setTargetVideoIndex, cellEnabled, setCellEnabled,
+    control1, setControl1, control2, setControl2, control3, setControl3, disableControls, setDisableControls
+  } = useCommonState(ac);
+  const [tissueComplete, setTissueComplete] = useState(false);
+
+  const initialPause = useInitialPause({ percentComplete: tPercentComplete, playing: playingTissue });
+
+  // Mark the video as incomplete whenever a control changes
+  useEffect(() => {
+    setTissueComplete(false);
+  }, [control1, control2, control3]);
+
+  // Track whether the tissue video has been completed
+  useEffect(() => {
+    if (tPercentComplete === 1) {
+      setTissueComplete(true);
+    }
+  }, [tPercentComplete]);
+
+  interface IRowHeader {
+    backgroundSvg: any;
+    headerText: string;
+    headerTextSub?: string;
+  }
+  const RowHeader = ({ backgroundSvg, headerText, headerTextSub }: IRowHeader) => (
+    <div className="row-header">
+      {backgroundSvg}
+      <div className="row-header-text">
+        {headerText}
+        {headerTextSub && (
+          <div className="row-header-text-sub">
+            {headerTextSub}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const tissueTitle = ac.organ === "brain" && control1 ? ac.o("ALTERNATESIMULATIONTITLE") : ac.o("LEFTSIMULATIONTITLE");
+  const disabledMessage = ac.t("DISABLEDCELLMESSAGE").replace("VIDEOTITLE", tissueTitle);
+  const hLabel = (bold: string, regular: string) => <><span className="bold">{bold}</span>&nbsp;{regular}</>;
+  const leftHLabel = hLabel(ac.o("LEFTXLABEL1"), ac.o("LEFTXLABEL2"));
+  const rightHLabel = hLabel(ac.o("RIGHTXLABEL1"), ac.o("RIGHTXLABEL2"));
+  return (
+    <AppContainer ac={ac} title={ac.o("SIMULATIONTITLE")}>
+      <div className="options-row">
+        <RowHeader backgroundSvg={<OptionsLabelBack />} headerText={ac.t("SIMOPTIONSHEADER")} />
+        { renderControls({ ac, disabled: disableControls,
+          onChanges: [
+            delayControl(setControl1, setDisableControls),
+            delayControl(setControl2, setDisableControls),
+            delayControl(setControl3, setDisableControls)
+          ] }) }
+        <div />
+      </div>
+      <div className="app-row">
+        <VideoView
+          ac={ac}
+          percentComplete={tPercentComplete}
+          playing={playingTissue}
+          setPercentComplete={setTPercentComplete}
+          setPlaying={setPlayingTissue}
+          setTargetVideoIndex={setTargetVideoIndex}
+          title={tissueTitle}
+          timelineMarks={timelines[ac.mode].tissue[ac.organ][+control1][+control2][+control3]}
+          videoFile={simVideos.tissue[ac.organ][+control1][+control2][+control3]}
+        />
+        <VideoView
+          ac={ac}
+          disabled={!cellEnabled || playingTissue}
+          disabledMessage={disabledMessage}
+          extraClass="cell-view"
+          percentComplete={cPercentComplete}
+          playing={playingCell}
+          setPercentComplete={setCPercentComplete}
+          setPlaying={setPlayingCell}
+          title={ac.o("RIGHTSIMULATIONTITLE")}
+          timelineMarks={timelines[ac.mode].cell[ac.organ][+control1][+control2][+control3]}
+          videoFile={simVideos.cell[ac.organ][+control1][+control2][+control3][targetVideoIndex]}
+        />
+      </div>
+      <div className="options-row">
+        <RowHeader
+          backgroundSvg={<ResultsLabelBack />}
+          headerText={ac.t("SIMRESULTSHEADER")}
+          headerTextSub={ac.t("SIMRESULTSSUB")}
+        />
+        <SimGraph
+          ac={ac}
+          data={graphData[ac.organ].left[+control1][+control2][+control3]}
+          percentComplete={tPercentComplete}
+          horizontalLabel={leftHLabel}
+          verticalLabel={ac.o("LEFTYLABEL")}
+          verticalRange={graphRanges[ac.organ].left[+control1][+control2][+control3]}
+          videoComplete={tissueComplete}
+        />
+        <SimGraph
+          ac={ac}
+          data={graphData[ac.organ].right[+control1][+control2][+control3]}
+          percentComplete={tPercentComplete}
+          horizontalLabel={rightHLabel}
+          verticalLabel={ac.o("RIGHTYLABEL")}
+          verticalRange={graphRanges[ac.organ].right[+control1][+control2][+control3]}
+          videoComplete={tissueComplete}
+        />
+        <div className={clsx("divider", ac.mode)} style={{height: 141}} />
+        <div className="key-box simulation">
+          <KeyButton ac={ac} onClick={() => setKeyVisible(state => !state)} />
+        </div>
+      </div>
+      <ZoomLayer
+        ac={ac}
+        setVideoEnabled={setCellEnabled}
+        show={initialPause}
+        type="cell"
+        zoomInfo={cellZoomData.simulation[ac.organ][+control1][+control2][0]}
+      />
+    </AppContainer>
+  );
+};

--- a/src/components/simulation-app.scss
+++ b/src/components/simulation-app.scss
@@ -1,5 +1,71 @@
 @use "./vars.scss";
 
+.simulation-body {
+  display: flex;
+  justify-content: space-between;
+  margin: 10px 7px 0 7px;
+
+  .control-column {
+    display: flex;
+    flex-direction: column;
+
+    .simulation-settings {
+      border: vars.$sim-border;
+      border-radius: vars.$sim-radius-settings;
+      height: 293px;
+      width: 379px;
+    }
+
+    .simulation-graphs {
+      border: 1px solid lightgray;
+      height: 45%;
+      width: 100%;
+    }
+  }
+
+  .video-column {
+    align-items: center;
+    background-color: vars.$sim-transparent-background;
+    border-radius: vars.$sim-radius-video-column;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+    padding: 17px;
+
+    .video {
+      background-color: black;
+      height: 280px;
+      width: 448px;
+    }
+  }
+}
+
+.simulation-footer {
+  display: flex;
+  gap: 10px;
+  margin: 0 12px 16px 16px;
+
+  .outcome-area {
+    align-items: center;
+    background-color: vars.$sim-transparent-background;
+    border-radius: 6px;
+    display: flex;
+    font-size: 18px;
+    height: 54px;
+    justify-content: center;
+    margin-right: 2px;
+    width: 740px;
+  }
+
+  .simulation-button {
+    background-color: white;
+    border: 3px solid black;
+    border-radius: 6px;
+    height: 54px;
+    width: 55px;
+  }
+}
+
 .options-row {
   display: flex;
   justify-content: space-between;

--- a/src/components/simulation-app.scss
+++ b/src/components/simulation-app.scss
@@ -2,8 +2,9 @@
 
 .simulation-body {
   display: flex;
+  height: 627px;
   justify-content: space-between;
-  margin: 10px 7px 0 7px;
+  margin: 10px 7px;
 
   .control-column {
     display: flex;
@@ -11,10 +12,27 @@
 
     .simulation-settings {
       border: vars.$sim-border;
-      border-radius: vars.$sim-radius-settings;
+      border-radius: 9px 9px vars.$sim-radius-settings vars.$sim-radius-settings;
+      // border-bottom-right-radius: vars.$sim-radius-settings;
+      // border-top-left-radius: 9px;
+      // border-top-right-radius: 
       box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
       height: 293px;
       width: 379px;
+
+      .settings-header {
+        align-items: center;
+        background-color: vars.$sim-dark-1;
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
+        color: white;
+        display: flex;
+        height: 26px;
+        justify-content: center;
+        width: 100%;
+      }
     }
 
     .simulation-graphs {
@@ -28,9 +46,11 @@
     align-items: center;
     background-color: vars.$sim-transparent-background;
     border-radius: vars.$sim-radius-video-column;
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     gap: 9px;
+    height: 603px;
     padding: 17px;
 
     .video {
@@ -44,7 +64,7 @@
 .simulation-footer {
   display: flex;
   gap: 10px;
-  margin: 0 12px 16px 16px;
+  margin: 0 5px 9px 9px;
 
   .outcome-area {
     align-items: center;

--- a/src/components/simulation-app.scss
+++ b/src/components/simulation-app.scss
@@ -16,7 +16,7 @@
       box-sizing: border-box;
       display: flex;
       flex-direction: column;
-      height: 293px;
+      height: 306px;
       width: 379px;
 
       .settings-header {
@@ -33,9 +33,16 @@
     }
 
     .simulation-graphs {
-      border: 1px solid lightgray;
+      align-items: center;
+      display: flex;
+      flex-direction: column;
       height: 45%;
+      margin-top: 17px;
       width: 100%;
+
+      .graphs-header {
+        font-weight: bold;
+      }
     }
   }
 

--- a/src/components/simulation-app.scss
+++ b/src/components/simulation-app.scss
@@ -12,6 +12,7 @@
     .simulation-settings {
       border: vars.$sim-border;
       border-radius: vars.$sim-radius-settings;
+      box-sizing: border-box;
       height: 293px;
       width: 379px;
     }

--- a/src/components/simulation-app.scss
+++ b/src/components/simulation-app.scss
@@ -12,7 +12,7 @@
 
     .simulation-settings {
       border: vars.$sim-border;
-      border-radius: 9px 9px vars.$sim-radius-settings vars.$sim-radius-settings;
+      border-radius: vars.$sim-radius-settings-top vars.$sim-radius-settings-top vars.$sim-radius-settings-bottom vars.$sim-radius-settings-bottom;
       box-sizing: border-box;
       display: flex;
       flex-direction: column;

--- a/src/components/simulation-app.scss
+++ b/src/components/simulation-app.scss
@@ -13,9 +13,6 @@
     .simulation-settings {
       border: vars.$sim-border;
       border-radius: 9px 9px vars.$sim-radius-settings vars.$sim-radius-settings;
-      // border-bottom-right-radius: vars.$sim-radius-settings;
-      // border-top-left-radius: 9px;
-      // border-top-right-radius: 
       box-sizing: border-box;
       display: flex;
       flex-direction: column;
@@ -85,48 +82,4 @@
     height: 54px;
     width: 55px;
   }
-}
-
-.options-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.row-header {
-  display: flex;
-  align-items: center;
-
-  width: 80px;
-}
-
-.options-header {
-  height: 60px;
-}
-
-.row-header-text {
-  position: absolute;
-  width: 54px;
-  padding-left: 10px;
-
-  font-family: vars.$font-clean;
-  font-weight: bold;
-  font-size: 14px;
-
-  .row-header-text-sub {
-    font-size: 12px;
-  }
-}
-
-.key-box.simulation {
-  width: 65px;
-  height: 141px;
-  background-color: vars.$sim-light-8;
-  padding-top: 8px;
-}
-
-.divider.simulation {
-  width: 1px;
-  height: 40px;
-  background-color: vars.$sim-basic;
 }

--- a/src/components/simulation-app.scss
+++ b/src/components/simulation-app.scss
@@ -58,9 +58,18 @@
     padding: 17px;
 
     .video {
+      align-items: center;
       background-color: black;
+      display: flex;
+      flex-direction: column;
       height: 280px;
+      position: relative;
       width: 448px;
+
+      .pane-title {
+        background-color: white;
+        margin-top: 10px;
+      }
     }
   }
 }

--- a/src/components/simulation-app.tsx
+++ b/src/components/simulation-app.tsx
@@ -75,7 +75,9 @@ export const SimulationApp = ({ ac/*, setKeyVisible*/ }: SimulationAppProps) => 
       <div className="simulation-body">
         <div className="control-column">
           <div className="simulation-settings">
-            Settings
+            <div className="settings-header">
+              Simulation Settings
+            </div>
           </div>
           <div className="simulation-graphs">
             Graphs

--- a/src/components/simulation-app.tsx
+++ b/src/components/simulation-app.tsx
@@ -1,22 +1,22 @@
-import React, { useEffect, useState } from "react";
+import React/*, { useEffect, useState }*/ from "react";
 import { clsx } from "clsx";
 
-import { VideoView } from "./video-view";
-import { KeyButton } from "./app-button";
+// import { VideoView } from "./video-view";
+// import { KeyButton } from "./app-button";
 import { AppContainer } from "./app-container";
-import { SimGraph } from "./sim-graph";
-import { ZoomLayer } from "./zoom-layer";
-import { renderControls } from "../data/control-data";
-import { graphData, graphRanges } from "../data/graph-data";
-import { simVideos, timelines } from "../data/video-data";
-import { cellZoomData } from "../data/zoom-data";
+// import { SimGraph } from "./sim-graph";
+// import { ZoomLayer } from "./zoom-layer";
+// import { renderControls } from "../data/control-data";
+// import { graphData, graphRanges } from "../data/graph-data";
+// import { simVideos, timelines } from "../data/video-data";
+// import { cellZoomData } from "../data/zoom-data";
 import { AppContext } from "../hooks/use-app-context";
-import { useCommonState } from "../hooks/use-common-state";
-import { useInitialPause } from "../hooks/use-initial-pause";
-import { delayControl } from "../utils/app-common";
+// import { useCommonState } from "../hooks/use-common-state";
+// import { useInitialPause } from "../hooks/use-initial-pause";
+// import { delayControl } from "../utils/app-common";
 
-import OptionsLabelBack from "../assets/backgrounds/options-label-back.svg";
-import ResultsLabelBack from "../assets/backgrounds/results-label-back.svg";
+// import OptionsLabelBack from "../assets/backgrounds/options-label-back.svg";
+// import ResultsLabelBack from "../assets/backgrounds/results-label-back.svg";
 
 import "./simulation-app.scss";
 
@@ -24,54 +24,76 @@ interface SimulationAppProps {
   ac: AppContext;
   setKeyVisible: (func: (value: boolean) => boolean) => void;
 }
-export const SimulationApp = ({ ac, setKeyVisible }: SimulationAppProps) => {
-  const { playingTissue, setPlayingTissue, tPercentComplete, setTPercentComplete, playingCell, setPlayingCell,
-    cPercentComplete, setCPercentComplete, targetVideoIndex, setTargetVideoIndex, cellEnabled, setCellEnabled,
-    control1, setControl1, control2, setControl2, control3, setControl3, disableControls, setDisableControls
-  } = useCommonState(ac);
-  const [tissueComplete, setTissueComplete] = useState(false);
+export const SimulationApp = ({ ac/*, setKeyVisible*/ }: SimulationAppProps) => {
+  // const { playingTissue, setPlayingTissue, tPercentComplete, setTPercentComplete, playingCell, setPlayingCell,
+  //   cPercentComplete, setCPercentComplete, targetVideoIndex, setTargetVideoIndex, cellEnabled, setCellEnabled,
+  //   control1, setControl1, control2, setControl2, control3, setControl3, disableControls, setDisableControls
+  // } = useCommonState(ac);
+  // const [tissueComplete, setTissueComplete] = useState(false);
 
-  const initialPause = useInitialPause({ percentComplete: tPercentComplete, playing: playingTissue });
+  // const initialPause = useInitialPause({ percentComplete: tPercentComplete, playing: playingTissue });
 
   // Mark the video as incomplete whenever a control changes
-  useEffect(() => {
-    setTissueComplete(false);
-  }, [control1, control2, control3]);
+  // useEffect(() => {
+  //   setTissueComplete(false);
+  // }, [control1, control2, control3]);
 
   // Track whether the tissue video has been completed
-  useEffect(() => {
-    if (tPercentComplete === 1) {
-      setTissueComplete(true);
-    }
-  }, [tPercentComplete]);
+  // useEffect(() => {
+  //   if (tPercentComplete === 1) {
+  //     setTissueComplete(true);
+  //   }
+  // }, [tPercentComplete]);
 
-  interface IRowHeader {
-    backgroundSvg: any;
-    headerText: string;
-    headerTextSub?: string;
-  }
-  const RowHeader = ({ backgroundSvg, headerText, headerTextSub }: IRowHeader) => (
-    <div className="row-header">
-      {backgroundSvg}
-      <div className="row-header-text">
-        {headerText}
-        {headerTextSub && (
-          <div className="row-header-text-sub">
-            {headerTextSub}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+  // interface IRowHeader {
+  //   backgroundSvg: any;
+  //   headerText: string;
+  //   headerTextSub?: string;
+  // }
+  // const RowHeader = ({ backgroundSvg, headerText, headerTextSub }: IRowHeader) => (
+  //   <div className="row-header">
+  //     {backgroundSvg}
+  //     <div className="row-header-text">
+  //       {headerText}
+  //       {headerTextSub && (
+  //         <div className="row-header-text-sub">
+  //           {headerTextSub}
+  //         </div>
+  //       )}
+  //     </div>
+  //   </div>
+  // );
 
-  const tissueTitle = ac.organ === "brain" && control1 ? ac.o("ALTERNATESIMULATIONTITLE") : ac.o("LEFTSIMULATIONTITLE");
-  const disabledMessage = ac.t("DISABLEDCELLMESSAGE").replace("VIDEOTITLE", tissueTitle);
-  const hLabel = (bold: string, regular: string) => <><span className="bold">{bold}</span>&nbsp;{regular}</>;
-  const leftHLabel = hLabel(ac.o("LEFTXLABEL1"), ac.o("LEFTXLABEL2"));
-  const rightHLabel = hLabel(ac.o("RIGHTXLABEL1"), ac.o("RIGHTXLABEL2"));
+  // const tissueTitle = ac.organ === "brain" && control1
+  //   ? ac.o("ALTERNATESIMULATIONTITLE") : ac.o("LEFTSIMULATIONTITLE");
+  // const disabledMessage = ac.t("DISABLEDCELLMESSAGE").replace("VIDEOTITLE", tissueTitle);
+  // const hLabel = (bold: string, regular: string) => <><span className="bold">{bold}</span>&nbsp;{regular}</>;
+  // const leftHLabel = hLabel(ac.o("LEFTXLABEL1"), ac.o("LEFTXLABEL2"));
+  // const rightHLabel = hLabel(ac.o("RIGHTXLABEL1"), ac.o("RIGHTXLABEL2"));
   return (
     <AppContainer ac={ac} title={ac.o("SIMULATIONTITLE")}>
-      <div className="options-row">
+      <div className="simulation-body">
+        <div className="control-column">
+          <div className="simulation-settings">
+            Settings
+          </div>
+          <div className="simulation-graphs">
+            Graphs
+          </div>
+        </div>
+        <div className="video-column">
+          <div className="video" />
+          <div className="video" />
+        </div>
+      </div>
+      <div className="simulation-footer">
+        <div className="outcome-area">
+          Outcome
+        </div>
+        <button className={clsx("simulation-button", "reset")}>Reset</button>
+        <button className={clsx("simulation-button", "key")}>Key</button>
+      </div>
+      {/* <div className="options-row">
         <RowHeader backgroundSvg={<OptionsLabelBack />} headerText={ac.t("SIMOPTIONSHEADER")} />
         { renderControls({ ac, disabled: disableControls,
           onChanges: [
@@ -142,7 +164,7 @@ export const SimulationApp = ({ ac, setKeyVisible }: SimulationAppProps) => {
         show={initialPause}
         type="cell"
         zoomInfo={cellZoomData.simulation[ac.organ][+control1][+control2][0]}
-      />
+      /> */}
     </AppContainer>
   );
 };

--- a/src/components/simulation-app.tsx
+++ b/src/components/simulation-app.tsx
@@ -80,7 +80,9 @@ export const SimulationApp = ({ ac/*, setKeyVisible*/ }: SimulationAppProps) => 
             </div>
           </div>
           <div className="simulation-graphs">
-            Graphs
+            <div className="graphs-header">
+              {ac.o("SIMGRAPHTITLE")}
+            </div>
           </div>
         </div>
         <div className="video-column">

--- a/src/components/simulation-app.tsx
+++ b/src/components/simulation-app.tsx
@@ -1,11 +1,6 @@
 import React/*, { useEffect, useState }*/ from "react";
 import { clsx } from "clsx";
 
-// import { VideoView } from "./video-view";
-// import { KeyButton } from "./app-button";
-import { AppContainer } from "./app-container";
-// import { SimGraph } from "./sim-graph";
-// import { ZoomLayer } from "./zoom-layer";
 // import { renderControls } from "../data/control-data";
 // import { graphData, graphRanges } from "../data/graph-data";
 // import { simVideos, timelines } from "../data/video-data";
@@ -14,6 +9,12 @@ import { AppContext } from "../hooks/use-app-context";
 // import { useCommonState } from "../hooks/use-common-state";
 // import { useInitialPause } from "../hooks/use-initial-pause";
 // import { delayControl } from "../utils/app-common";
+// import { KeyButton } from "./app-button";
+import { AppContainer } from "./app-container";
+import { PaneTitle } from "./pane-title";
+// import { SimGraph } from "./sim-graph";
+// import { VideoView } from "./video-view";
+// import { ZoomLayer } from "./zoom-layer";
 
 // import OptionsLabelBack from "../assets/backgrounds/options-label-back.svg";
 // import ResultsLabelBack from "../assets/backgrounds/results-label-back.svg";
@@ -86,8 +87,12 @@ export const SimulationApp = ({ ac/*, setKeyVisible*/ }: SimulationAppProps) => 
           </div>
         </div>
         <div className="video-column">
-          <div className="video" />
-          <div className="video" />
+          <div className="video">
+            <PaneTitle title={ac.o("LEFTSIMULATIONTITLE")} />
+          </div>
+          <div className="video">
+            <PaneTitle title={ac.o("RIGHTSIMULATIONTITLE")} />
+          </div>
         </div>
       </div>
       <div className="simulation-footer">

--- a/src/components/title.scss
+++ b/src/components/title.scss
@@ -6,31 +6,34 @@
   justify-content: space-between;
   padding: 4px;
   font-weight: 700;
-  
+
   &.animation {
     border-radius: vars.$ani-radius-normal;
     background-color: vars.$ani-light-6;
 
     .title-close-button {
       background-color: vars.$ani-light-6;
-    
+
       &:hover {
         background-color: vars.$ani-light-4;
       }
+
       &:active {
         background-color: vars.$ani-light-2;
       }
     }
   }
+
   &.simulation {
     background-color: vars.$sim-light-5;
 
     .title-close-button {
       background-color: vars.$sim-light-5;
-    
+
       &:hover {
         background-color: vars.$sim-light-3;
       }
+
       &:active {
         background-color: vars.$sim-light-2;
       }

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -33,7 +33,8 @@ $sim-border: 4px solid $sim-dark-1;
 $sim-radius-button: 5px;
 $sim-radius-cell: 10px;
 $sim-radius-container: 5px;
-$sim-radius-settings: 20px;
+$sim-radius-settings-bottom: 20px;
+$sim-radius-settings-top: 9px;
 $sim-radius-video: 7px;
 $sim-radius-video-column: 12px;
 

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -26,13 +26,16 @@ $sim-light-4: #b7e2ec;
 $sim-light-5: #cdebf2;
 $sim-light-7: #e2f4f8;
 $sim-light-8: #f0f9fb;
+$sim-transparent-background: rgba(205, 235, 242, 0.39);
 
-$sim-border: 2px solid $sim-dark-1;
+$sim-border: 4px solid $sim-dark-1;
 
 $sim-radius-button: 5px;
-$sim-radius-container: 5px;
 $sim-radius-cell: 10px;
+$sim-radius-container: 5px;
+$sim-radius-settings: 20px;
 $sim-radius-video: 7px;
+$sim-radius-video-column: 12px;
 
 $cell-orange: #ff8415;
 $cell-border: 2px solid $cell-orange;

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -53,6 +53,10 @@
   "NOSE.SIMCONTROL3OPTION1": "Low",
   "NOSE.SIMCONTROL3OPTION2": "High",
 
+  "HEART.SIMGRAPHTITLE": "Results: Plaque Size Over Time",
+  "NOSE.SIMGRAPHTITLE": "Results: Mucus Generation Over Time",
+  "BRAIN.SIMGRAPHTITLE": "Results: Connections Over Time",
+
   "HEART.ANICONTROL1LABEL": "Stress Level",
   "HEART.ANICONTROL1OPTION1": "Low",
   "HEART.ANICONTROL1OPTION2": "High",


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186769675

This PR starts building the new simulation.
- It displays the title properly, lays out the other components of the simulation, and starts to style them.
- The old simulation has been moved to a new component so it can still be used for reference as we build the new one, but this should be removed once we finish this line of work.
- A lot of the old code from `simulation-app.tsx` has been left in the file but commented out for reference; this code should also be removed once it's no longer useful.
- A few cypress tests were turned off because the functionality they test has been removed. They should be turned back on when that functionality has been reimplemented.