### PR TITLE
186769600 Show and Hide Output Message Based on Time

### DIFF
--- a/src/components/new-simulation/simulation-outcome.tsx
+++ b/src/components/new-simulation/simulation-outcome.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { useAppContext } from "../../hooks/use-app-context";
 
@@ -7,10 +7,11 @@ import "./simulation-outcome.scss";
 interface ISimulationOutcomeProps {
   control1: boolean;
   control2: boolean;
+  outcomeHidden: boolean;
+  setOutcomeHidden: (v: boolean) => void;
 }
-export function SimulationOutcome({ control1, control2 }: ISimulationOutcomeProps) {
+export function SimulationOutcome({ control1, control2, outcomeHidden, setOutcomeHidden }: ISimulationOutcomeProps) {
   const ac = useAppContext();
-  const [hidden, setHidden] = useState(false);
   let message = "OUTCOMEHEALTHY";
   if (ac.organ === "brain") {
     if (control2){
@@ -24,13 +25,13 @@ export function SimulationOutcome({ control1, control2 }: ISimulationOutcomeProp
     }
   }
 
-  if (hidden) {
-    return <button className="simulation-button result" onClick={() => setHidden(false)} />;
+  if (outcomeHidden) {
+    return <button className="simulation-button result" onClick={() => setOutcomeHidden(false)} />;
   } else {
     return (
       <div className="outcome-area">
         {ac.o(message)}
-        <button className="hide-button" onClick={() => setHidden(true)} />
+        <button className="hide-button" onClick={() => setOutcomeHidden(true)} />
       </div>
     );
   }

--- a/src/components/new-simulation/simulation-settings.tsx
+++ b/src/components/new-simulation/simulation-settings.tsx
@@ -22,16 +22,16 @@ interface ISimulationSettingsProps {
   keyVisible: boolean;
   playingVideo: boolean;
   setKeyVisible: (val: boolean) => void;
+  setOutcomeHidden: (val: boolean) => void;
   setPlayingVideo: (val: boolean) => void;
   simulationTime: number;
   setSimulationTime: (val: number) => void;
-  setExperimentIsRun: (c1: boolean, c2: boolean) => void;
   resetExperiments: () => void;
 }
 export function SimulationSettings({
   control1, setControl1, control2, setControl2, keyVisible, setKeyVisible,
-  playingVideo, setPlayingVideo, simulationTime, setSimulationTime, 
-  setExperimentIsRun, resetExperiments
+  playingVideo, setOutcomeHidden, setPlayingVideo, simulationTime, setSimulationTime, 
+  resetExperiments
 }: ISimulationSettingsProps) {
   const ac = useAppContext();
   const [anySettingsChanged, setAnySettingsChanged] = useState(false);
@@ -40,6 +40,7 @@ export function SimulationSettings({
   const onSliderChange = (value: number | number[]) => {
     if (Array.isArray(value)) return;
     setSimulationTime(value);
+    setOutcomeHidden(value < 2);
     setPlayingVideo(true);
     setAnySettingsChanged(true);
   };

--- a/src/components/new-simulation/simulation-video.tsx
+++ b/src/components/new-simulation/simulation-video.tsx
@@ -13,12 +13,14 @@ interface ISimulationVideo {
   control1: boolean;
   control2: boolean;
   displayOutcome: boolean;
+  outcomeHidden: boolean;
   playing: boolean;
   setExperimentIsRun: (v1: boolean, v2: boolean) => void;
+  setOutcomeHidden: (v: boolean) => void;
   simulationTime: number;
 }
 export const SimulationVideo = ({
-  control1, control2, displayOutcome, playing, setExperimentIsRun, simulationTime
+  control1, control2, displayOutcome, outcomeHidden, playing, setExperimentIsRun, setOutcomeHidden, simulationTime
 }: ISimulationVideo) => {
   const ac = useAppContext();
   const videoFile = simVideos[ac.organ][+control1][+control2][simulationTime] ?? simVideos.heart[0][0][0];
@@ -110,6 +112,8 @@ export const SimulationVideo = ({
       {displayOutcome && <SimulationOutcome
         control1={control1}
         control2={control2}
+        outcomeHidden={outcomeHidden}
+        setOutcomeHidden={setOutcomeHidden}
       />}
     </div>
   );

--- a/src/components/simulation-app.tsx
+++ b/src/components/simulation-app.tsx
@@ -20,6 +20,7 @@ export const SimulationApp = ({ keyVisible, setKeyVisible }: SimulationAppProps)
   const { control1, setControl1, control2, setControl2 } = useCommonState(ac);
   const [simulationTime, setSimulationTime] = useState(0);
   const [playingVideo, setPlayingVideo] = useState(false);
+  const [outcomeHidden, setOutcomeHidden] = useState(false);
 
   const { experimentState, setExperimentIsFirstSeen, setExperimentIsRun, setGraphIsShowing, resetExperiments }
     = useExperimentState();
@@ -36,10 +37,10 @@ export const SimulationApp = ({ keyVisible, setKeyVisible }: SimulationAppProps)
             keyVisible={keyVisible}
             playingVideo={playingVideo}
             setKeyVisible={setKeyVisible}
+            setOutcomeHidden={setOutcomeHidden}
             setPlayingVideo={setPlayingVideo}
             simulationTime={simulationTime}
             setSimulationTime={setSimulationTime}
-            setExperimentIsRun={setExperimentIsRun}
             resetExperiments={resetExperiments}
           />
           <SimulationResults
@@ -55,8 +56,10 @@ export const SimulationApp = ({ keyVisible, setKeyVisible }: SimulationAppProps)
           control1={control1}
           control2={control2}
           displayOutcome={experimentState[+control1][+control2].complete}
+          outcomeHidden={outcomeHidden}
           playing={playingVideo}
           setExperimentIsRun={setExperimentIsRun}
+          setOutcomeHidden={setOutcomeHidden}
           simulationTime={simulationTime}
         />
         <MagnifyImage control1={control1} />


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186769600

This PR adds additional functionality to the outcome message, requested by the PI after the initial story was complete. The outcome message now automatically hides (shows the Result button) when switching to the first or second time and automatically shows (shows the message and x button) when switching to the final time. Note that this is independent of the message being revealed in the first place, which only happens after the video at the final time of a particular experiment setup has completed.