### PR TITLE
186963497 Update Outcome Styling

### DIFF
--- a/src/components/new-simulation/simulation-outcome.scss
+++ b/src/components/new-simulation/simulation-outcome.scss
@@ -5,6 +5,7 @@
   background-color: vars.$sim-light-7;
   border-radius: 6px;
   bottom: 42px;
+  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
   box-sizing: border-box;
   color: black;
   display: flex;
@@ -17,30 +18,14 @@
   position: absolute;
   text-align: center;
   width: 398px;
-
-  .outcome-border {
-    border: 3px solid vars.$sim-dark-1;
-    border-radius: 3px;
-    box-sizing: border-box;
-    height: 44px;
-    margin: 5px;
+  
+  .outcome-svg {
+    fill: none;
     position: absolute;
-    width: 388px;
 
-    &.line-style-0 {
-      border-style: solid;
-    }
-
-    &.line-style-1 {
-      border-style: dashed;
-    }
-
-    &.line-style-2 {
-      border-style: dotted;
-    }
-
-    &.line-style-3 {
-      border-style: dashed;
+    .outcome-border {
+      stroke: vars.$sim-dark-1;
+      stroke-width: 3; // Keep in sync with strokeWidth in simulation-outcome.tsx
     }
   }
 

--- a/src/components/new-simulation/simulation-outcome.scss
+++ b/src/components/new-simulation/simulation-outcome.scss
@@ -18,8 +18,34 @@
   text-align: center;
   width: 398px;
 
+  .outcome-border {
+    border: 3px solid vars.$sim-dark-1;
+    border-radius: 3px;
+    box-sizing: border-box;
+    height: 44px;
+    margin: 5px;
+    position: absolute;
+    width: 388px;
+
+    &.line-style-0 {
+      border-style: solid;
+    }
+
+    &.line-style-1 {
+      border-style: dashed;
+    }
+
+    &.line-style-2 {
+      border-style: dotted;
+    }
+
+    &.line-style-3 {
+      border-style: dashed;
+    }
+  }
+
   .hide-button {
-    background-color: rgba(0,0,0,0);
+    background-color: vars.$sim-light-7;
     background-image: url(../../assets/new-sim/buttons/close-icon.svg);
     border: none;
     cursor: pointer;

--- a/src/components/new-simulation/simulation-outcome.tsx
+++ b/src/components/new-simulation/simulation-outcome.tsx
@@ -1,6 +1,8 @@
+import { clsx } from "clsx";
 import React from "react";
 
 import { useAppContext } from "../../hooks/use-app-context";
+import { getAllExperiments } from "../../utils/control-utils";
 
 import "./simulation-outcome.scss";
 
@@ -28,9 +30,13 @@ export function SimulationOutcome({ control1, control2, outcomeHidden, setOutcom
   if (outcomeHidden) {
     return <button className="simulation-button result" onClick={() => setOutcomeHidden(false)} />;
   } else {
+    const index = getAllExperiments(ac).findIndex(
+      controls => controls.option1 === control1 && controls.option2 === control2);
+    const borderClass = "line-style-" + index;
     return (
       <div className="outcome-area">
-        {ac.o(message)}
+        <div className={clsx("outcome-border", borderClass)} />
+        {`${ac.t("OUTCOMEPREFIX")}${ac.o(message)}`}
         <button className="hide-button" onClick={() => setOutcomeHidden(true)} />
       </div>
     );

--- a/src/components/new-simulation/simulation-outcome.tsx
+++ b/src/components/new-simulation/simulation-outcome.tsx
@@ -30,24 +30,14 @@ export function SimulationOutcome({ control1, control2, outcomeHidden, setOutcom
   if (outcomeHidden) {
     return <button className="simulation-button result" onClick={() => setOutcomeHidden(false)} />;
   } else {
-    // Determine style and path of outcome border
     // The border uses the same dashed style as the graph curves, so it must be an svg
-    // The border has rounded corners, so it's a combination of lines and arcs
     const index = getAllExperiments(ac).findIndex(
       controls => controls.option1 === control1 && controls.option2 === control2);
     const borderClass = "line-style-" + index;
     const strokeWidth = 3; // Keep in sync with .outcome-border stroke-width in simulation-outcome.scss
+    const halfStrokeWidth = strokeWidth / 2;
     const borderHeight = 48; // Based on .outcome-area height in simulation-outcome.scss - margin space
     const borderWidth = 392; // Based on .outcome-area width in simulation-outcome.scss - margin space
-    const borderRadius = 3;
-    const bWidth = borderWidth - (2 * borderRadius + strokeWidth);
-    const bHeight = borderHeight - (2 * borderRadius + strokeWidth);
-    const aPrefix = `${borderRadius},${borderRadius} 0 0 1`;
-    const top = `h ${bWidth} a ${aPrefix} ${borderRadius},${borderRadius}`;
-    const right = `v ${bHeight} a ${aPrefix} -${borderRadius},${borderRadius}`;
-    const bottom = `h -${bWidth} a ${aPrefix} -${borderRadius},-${borderRadius}`;
-    const left = `v -${bHeight} a ${aPrefix} ${borderRadius},-${borderRadius}`;
-    const path = `M ${borderRadius + strokeWidth / 2},${strokeWidth / 2} ${top} ${right} ${bottom} ${left} z`;
     return (
       <div className="outcome-area">
         <svg
@@ -56,7 +46,14 @@ export function SimulationOutcome({ control1, control2, outcomeHidden, setOutcom
           width={borderWidth}
           xmlns="http://www.w3.org/2000/svg" 
         >
-          <path d={path} className={clsx("outcome-border", borderClass)} />
+          <rect
+            x={halfStrokeWidth}
+            y={halfStrokeWidth}
+            height={borderHeight - strokeWidth}
+            width={borderWidth - strokeWidth}
+            rx={2}
+            className={clsx("outcome-border", borderClass)}
+          />
         </svg>
         {`${ac.t("OUTCOMEPREFIX")}${ac.o(message)}`}
         <button className="hide-button" onClick={() => setOutcomeHidden(true)} />

--- a/src/components/new-simulation/simulation-outcome.tsx
+++ b/src/components/new-simulation/simulation-outcome.tsx
@@ -30,12 +30,34 @@ export function SimulationOutcome({ control1, control2, outcomeHidden, setOutcom
   if (outcomeHidden) {
     return <button className="simulation-button result" onClick={() => setOutcomeHidden(false)} />;
   } else {
+    // Determine style and path of outcome border
+    // The border uses the same dashed style as the graph curves, so it must be an svg
+    // The border has rounded corners, so it's a combination of lines and arcs
     const index = getAllExperiments(ac).findIndex(
       controls => controls.option1 === control1 && controls.option2 === control2);
     const borderClass = "line-style-" + index;
+    const strokeWidth = 3; // Keep in sync with .outcome-border stroke-width in simulation-outcome.scss
+    const borderHeight = 48; // Based on .outcome-area height in simulation-outcome.scss - margin space
+    const borderWidth = 392; // Based on .outcome-area width in simulation-outcome.scss - margin space
+    const borderRadius = 3;
+    const bWidth = borderWidth - (2 * borderRadius + strokeWidth);
+    const bHeight = borderHeight - (2 * borderRadius + strokeWidth);
+    const aPrefix = `${borderRadius},${borderRadius} 0 0 1`;
+    const top = `h ${bWidth} a ${aPrefix} ${borderRadius},${borderRadius}`;
+    const right = `v ${bHeight} a ${aPrefix} -${borderRadius},${borderRadius}`;
+    const bottom = `h -${bWidth} a ${aPrefix} -${borderRadius},-${borderRadius}`;
+    const left = `v -${bHeight} a ${aPrefix} ${borderRadius},-${borderRadius}`;
+    const path = `M ${borderRadius + strokeWidth / 2},${strokeWidth / 2} ${top} ${right} ${bottom} ${left} z`;
     return (
       <div className="outcome-area">
-        <div className={clsx("outcome-border", borderClass)} />
+        <svg
+          className="outcome-svg"
+          height={borderHeight} 
+          width={borderWidth}
+          xmlns="http://www.w3.org/2000/svg" 
+        >
+          <path d={path} className={clsx("outcome-border", borderClass)} />
+        </svg>
         {`${ac.t("OUTCOMEPREFIX")}${ac.o(message)}`}
         <button className="hide-button" onClick={() => setOutcomeHidden(true)} />
       </div>

--- a/src/components/new-simulation/simulation-results.scss
+++ b/src/components/new-simulation/simulation-results.scss
@@ -75,21 +75,4 @@
     stroke: vars.$data-grey;
     stroke-width: 4;
   }
-
-}
-
-.line-style-0 {
-  stroke-dasharray: none;
-}
-
-.line-style-1 {
-  stroke-dasharray: 8 4;
-}
-
-.line-style-2 {
-  stroke-dasharray: 4 3;
-}
-
-.line-style-3 {
-  stroke-dasharray: 20 4;
 }

--- a/src/components/simulation-app.scss
+++ b/src/components/simulation-app.scss
@@ -140,3 +140,20 @@
     }
   }
 }
+
+// Styles used for dashed lines in graphs, etc
+.line-style-0 {
+  stroke-dasharray: none;
+}
+
+.line-style-1 {
+  stroke-dasharray: 8 4;
+}
+
+.line-style-2 {
+  stroke-dasharray: 4 3;
+}
+
+.line-style-3 {
+  stroke-dasharray: 20 4;
+}

--- a/src/data/graph-data.ts
+++ b/src/data/graph-data.ts
@@ -164,7 +164,7 @@ export function getSVGPath(organ: string, control1: boolean, control2: boolean) 
   }
 }
 
-export function formatPair(pair: Pair) {
+function formatPair(pair: Pair) {
   return `${pair[0]},${pair[1]}`;
 }
 

--- a/src/data/graph-data.ts
+++ b/src/data/graph-data.ts
@@ -164,7 +164,7 @@ export function getSVGPath(organ: string, control1: boolean, control2: boolean) 
   }
 }
 
-function formatPair(pair: Pair) {
+export function formatPair(pair: Pair) {
   return `${pair[0]},${pair[1]}`;
 }
 

--- a/src/utils/translation/lang/en-us.json
+++ b/src/utils/translation/lang/en-us.json
@@ -164,6 +164,7 @@
   "BRAIN.RIGHTXLABEL2": "(weeks)",
   "BRAIN.RIGHTYLABEL": "Signals Transmitted",
 
+  "OUTCOMEPREFIX": "Result: ",
   "HEART.OUTCOMEHEALTHY": "A person would have a low risk of blocked blood vessels in the heart.",
   "HEART.OUTCOMEINTERMEDIATE": "A person would have a medium risk of blocked blood vessels in the heart.",
   "HEART.OUTCOMECHRONIC": "A person would have a high risk of blocked blood vessels in the heart.",


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186963497

This PR makes one major and a couple of minor styling changes to the output messages.
- The major change is adding an svg border with styling that matches the experiment's graph curve style. This involved moving some css from a specific file to a more general file.
- Added "Result: " before each output message.
- Added a subtle box shadow to the output message area.