### PR TITLE
186967561 Stop Playing Video When Toggle Button Is Pressed

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -84,7 +84,7 @@ context("Test the overall app", () => {
       toggleButtons().eq(3).should("have.class", "selected");
       graphCheckboxes().eq(0).should("be.checked");
       graphCheckboxes().eq(1).should("be.checked");
-      getSimulationPlayButton().should("have.class", "playing");
+      getSimulationPlayButton().should("not.have.class", "playing");
 
       resetButton().should("be.enabled").click();
       everythingIsDefaults();
@@ -116,7 +116,7 @@ context("Test the overall app", () => {
       outcomeArea().should("not.exist");
       cy.get(".app .simulation-settings .rc-slider").click("right");
       getSimulationPlayButton().should("have.class", "playing");
-      cy.wait(6000);
+      cy.wait(4500);
       outcomeArea().should("exist");
       resultButton().should("not.exist");
       closeOutcomeButton().should("exist").click();
@@ -125,13 +125,13 @@ context("Test the overall app", () => {
       resultButton().should("not.exist");
       closeOutcomeButton().should("exist");
     });
-    it(`brain videos switch and start playing when brain region changes`, () => {
+    it(`brain videos switch when brain region changes`, () => {
       visitPage("simulation", "brain");
       topVideoTitle().should("have.text", "Simulated Prefrontal Cortex");
       getSimulationPlayButton().should("not.have.class", "playing");
       toggleButtons().eq(1).click();
       topVideoTitle().should("have.text", "Simulated Amygdala");
-      getSimulationPlayButton().should("have.class", "playing");
+      getSimulationPlayButton().should("not.have.class", "playing");
     });
     it(`graphs and checkboxes work correctly`, () => {
       graphCheckboxes().eq(0).should("be.checked").should("be.enabled");

--- a/src/components/new-simulation/button-toggle.tsx
+++ b/src/components/new-simulation/button-toggle.tsx
@@ -8,13 +8,12 @@ import "./button-toggle.scss";
 interface IButtonToggleProps {
   controlNumber: number; // 1 for the top control, 2 for the bottom control
   leftClass?: string | boolean;
-  playVideo: () => void;
   rightClass?: string | boolean;
   setValue: (value: boolean) => void;
   value: boolean;
 }
 export function ButtonToggle({
-  controlNumber, leftClass, playVideo, rightClass, setValue, value
+  controlNumber, leftClass, rightClass, setValue, value
 }: IButtonToggleProps) {
   const ac = useAppContext();
   // Some controls are rendered inverted (true is on the left)
@@ -23,7 +22,6 @@ export function ButtonToggle({
   const leftSelected = invert ? value : !value;
   const rightSelected = invert ? !value : value;
   const handleButtonClick = (val: boolean) => {
-    playVideo();
     setValue(val);
   };
   const leftOnClick = () => handleButtonClick(!!invert);

--- a/src/components/new-simulation/simulation-settings.tsx
+++ b/src/components/new-simulation/simulation-settings.tsx
@@ -92,14 +92,12 @@ export function SimulationSettings({
       <ButtonToggle
         controlNumber={1}
         leftClass={isBrain && "brain1"}
-        playVideo={() => setPlayingVideo(true)}
         rightClass={isBrain && "brain2"}
         setValue={(v) => { setControl1(v); setAnySettingsChanged(true); }}
         value={control1}
       />
       <ButtonToggle
         controlNumber={2}
-        playVideo={() => setPlayingVideo(true)}
         setValue={(v) => { setControl2(v); setAnySettingsChanged(true); }}
         value={control2}
       />


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186967561

This PR makes a small change to the simulation UI. Previously, pressing any toggle button (changing the experiment conditions) would start playing the video. Now, the new video will not play if it wasn't already playing before pressing the button.